### PR TITLE
Add Server::listen() method instead of accepting socket in constructor

### DIFF
--- a/examples/11-server.php
+++ b/examples/11-server.php
@@ -7,12 +7,12 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = React\EventLoop\Factory::create();
 
-// listen on 127.0.0.1:1080 or first argument
-$listen = isset($argv[1]) ? $argv[1] : '127.0.0.1:1080';
-$socket = new Socket($listen, $loop);
+// start a new SOCKS proxy server
+$server = new Server($loop);
 
-// start a new server listening for incoming connection on the given socket
-$server = new Server($loop, $socket);
+// listen on 127.0.0.1:1080 or first argument
+$socket = new Socket(isset($argv[1]) ? $argv[1] : '127.0.0.1:1080', $loop);
+$server->listen($socket);
 
 echo 'SOCKS server listening on ' . $socket->getAddress() . PHP_EOL;
 

--- a/examples/12-server-with-password.php
+++ b/examples/12-server-with-password.php
@@ -7,17 +7,17 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = React\EventLoop\Factory::create();
 
-// listen on 127.0.0.1:1080 or first argument
-$listen = isset($argv[1]) ? $argv[1] : '127.0.0.1:1080';
-$socket = new Socket($listen, $loop);
-
-// start a new server listening for incoming connection on the given socket
+// start a new SOCKS proxy server
 // require authentication and hence make this a SOCKS5-only server
-$server = new Server($loop, $socket);
+$server = new Server($loop);
 $server->setAuthArray(array(
     'tom' => 'god',
     'user' => 'p@ssw0rd'
 ));
+
+// listen on 127.0.0.1:1080 or first argument
+$socket = new Socket(isset($argv[1]) ? $argv[1] : '127.0.0.1:1080', $loop);
+$server->listen($socket);
 
 echo 'SOCKS5 server requiring authentication listening on ' . $socket->getAddress() . PHP_EOL;
 

--- a/examples/13-server-blacklist.php
+++ b/examples/13-server-blacklist.php
@@ -28,12 +28,12 @@ $connector = new ConnectionManagerSelective(array(
     '*' => $permit
 ));
 
-// listen on 127.0.0.1:1080 or first argument
-$listen = isset($argv[1]) ? $argv[1] : '127.0.0.1:1080';
-$socket = new Socket($listen, $loop);
+// start a new SOCKS proxy server using our connection manager for outgoing connections
+$server = new Server($loop, $connector);
 
-// start the actual socks server on the given server socket and using our connection manager for outgoing connections
-$server = new Server($loop, $socket, $connector);
+// listen on 127.0.0.1:1080 or first argument
+$socket = new Socket(isset($argv[1]) ? $argv[1] : '127.0.0.1:1080', $loop);
+$server->listen($socket);
 
 echo 'SOCKS server listening on ' . $socket->getAddress() . PHP_EOL;
 

--- a/examples/21-server-proxy-chaining.php
+++ b/examples/21-server-proxy-chaining.php
@@ -30,11 +30,12 @@ foreach ($path as $proxy) {
     $connector = new Client($proxy, $connector);
 }
 
+// start a new SOCKS proxy server which forwards all connections to the other SOCKS server
+$server = new Server($loop, $connector);
+
 // listen on 127.0.0.1:1080 or first argument
 $socket = new Socket($listen, $loop);
-
-// start a new server which forwards all connections to the other SOCKS server
-$server = new Server($loop, $socket, $connector);
+$server->listen($socket);
 
 echo 'SOCKS server listening on ' . $socket->getAddress() . PHP_EOL;
 echo 'Forwarding via: ' . implode(' -> ', $path) . PHP_EOL;

--- a/examples/22-server-proxy-chaining-from-random-pool.php
+++ b/examples/22-server-proxy-chaining-from-random-pool.php
@@ -35,10 +35,12 @@ foreach ($pool as $proxy) {
 }
 $connector = new ConnectionManagerRandom($clients);
 
-$socket = new Socket($listen, $loop);
-
-// start the actual socks server on the given server socket and using our connection manager for outgoing connections
+// start the SOCKS proxy server using our connection manager for outgoing connections
 $server = new Server($loop, $socket, $connector);
+
+// listen on 127.0.0.1:1080 or first argument
+$socket = new Socket($listen, $loop);
+$server->listen($socket);
 
 echo 'SOCKS server listening on ' . $socket->getAddress() . PHP_EOL;
 echo 'Randomly picking from: ' . implode(', ', $pool) . PHP_EOL;

--- a/examples/31-server-secure.php
+++ b/examples/31-server-secure.php
@@ -7,14 +7,14 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $loop = React\EventLoop\Factory::create();
 
+// start a new SOCKS proxy server
+$server = new Server($loop);
+
 // listen on tls://127.0.0.1:1080 or first argument
 $listen = isset($argv[1]) ? $argv[1] : '127.0.0.1:1080';
 $socket = new Socket('tls://' . $listen, $loop, array('tls' => array(
     'local_cert' => __DIR__ . '/localhost.pem',
 )));
-
-// start a new server listening for incoming connection on the given socket
-$server = new Server($loop, $socket);
 
 echo 'SOCKS over TLS server listening on ' . str_replace('tls:', 'sockss:', $socket->getAddress()) . PHP_EOL;
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -43,7 +43,7 @@ final class Server
 
     private $protocolVersion = null;
 
-    public function __construct(LoopInterface $loop, ServerInterface $serverInterface, ConnectorInterface $connector = null)
+    public function __construct(LoopInterface $loop, ConnectorInterface $connector = null)
     {
         if ($connector === null) {
             $connector = new Connector($loop);
@@ -51,9 +51,16 @@ final class Server
 
         $this->loop = $loop;
         $this->connector = $connector;
+    }
 
+    /**
+     * @param ServerInterface $socket
+     * @return void
+     */
+    public function listen(ServerInterface $socket)
+    {
         $that = $this;
-        $serverInterface->on('connection', function ($connection) use ($that) {
+        $socket->on('connection', function ($connection) use ($that) {
             $that->onConnection($connection);
         });
     }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -30,7 +30,8 @@ class FunctionalTest extends TestCase
         $this->port = parse_url($address, PHP_URL_PORT);
         $this->assertNotEquals(0, $this->port);
 
-        $this->server = new Server($this->loop, $socket);
+        $this->server = new Server($this->loop);
+        $this->server->listen($socket);
         $this->connector = new TcpConnector($this->loop);
         $this->client = new Client('127.0.0.1:' . $this->port, $this->connector);
     }
@@ -113,7 +114,8 @@ class FunctionalTest extends TestCase
         $socket = new \React\Socket\Server('tls://127.0.0.1:0', $this->loop, array('tls' => array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem',
         )));
-        $this->server = new Server($this->loop, $socket);
+        $this->server = new Server($this->loop);
+        $this->server->listen($socket);
 
         $this->connector = new Connector($this->loop, array('tls' => array(
             'verify_peer' => false,
@@ -137,7 +139,8 @@ class FunctionalTest extends TestCase
         $socket = new \React\Socket\Server('tls://127.0.0.1:0', $this->loop, array('tls' => array(
             'local_cert' => __DIR__ . '/../examples/localhost.pem',
         )));
-        $this->server = new Server($this->loop, $socket);
+        $this->server = new Server($this->loop);
+        $this->server->listen($socket);
 
         $this->connector = new Connector($this->loop, array('tls' => array(
             'verify_peer' => false,
@@ -157,7 +160,8 @@ class FunctionalTest extends TestCase
 
         $path = sys_get_temp_dir() . '/test' . mt_rand(1000, 9999) . '.sock';
         $socket = new UnixServer($path, $this->loop);
-        $this->server = new Server($this->loop, $socket);
+        $this->server = new Server($this->loop);
+        $this->server->listen($socket);
 
         $this->connector = new Connector($this->loop);
         $this->client = new Client('socks+unix://' . $path, $this->connector);
@@ -176,7 +180,8 @@ class FunctionalTest extends TestCase
 
         $path = sys_get_temp_dir() . '/test' . mt_rand(1000, 9999) . '.sock';
         $socket = new UnixServer($path, $this->loop);
-        $this->server = new Server($this->loop, $socket);
+        $this->server = new Server($this->loop);
+        $this->server->listen($socket);
         $this->server->setProtocolVersion(5);
 
         $this->connector = new Connector($this->loop);
@@ -196,7 +201,8 @@ class FunctionalTest extends TestCase
 
         $path = sys_get_temp_dir() . '/test' . mt_rand(1000, 9999) . '.sock';
         $socket = new UnixServer($path, $this->loop);
-        $this->server = new Server($this->loop, $socket);
+        $this->server = new Server($this->loop);
+        $this->server->listen($socket);
         $this->server->setAuthArray(array('name' => 'pass'));
 
         $this->connector = new Connector($this->loop);

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -12,16 +12,23 @@ class ServerTest extends TestCase
 
     public function setUp()
     {
-        $socket = $this->getMockBuilder('React\Socket\ServerInterface')
-            ->getMock();
-
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')
             ->getMock();
 
         $this->connector = $this->getMockBuilder('React\Socket\ConnectorInterface')
             ->getMock();
 
-        $this->server = new Server($loop, $socket, $this->connector);
+        $this->server = new Server($loop, $this->connector);
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testListen()
+    {
+        $socket = $this->getMockBuilder('React\Socket\ServerInterface')->getMock();
+
+        $this->server->listen($socket);
     }
 
     public function testSetProtocolVersion()


### PR DESCRIPTION
```php
// old
$socket = new React\Socket\Server(1080, $loop);
$server = new Clue\React\Socks\Server($loop, $socket);

// new
$server = new Clue\React\Socks\Server($loop);
$socket = new React\Socket\Server(1080, $loop);
$server->listen($socket);
```