### PR TITLE
Improve error reporting by always including target URI in exceptions

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,7 +8,6 @@ class TestCase extends PHPUnit\Framework\TestCase
     {
         $mock = $this->createCallableMock();
 
-
         if (func_num_args() > 0) {
             $mock
                 ->expects($this->once())
@@ -23,6 +22,18 @@ class TestCase extends PHPUnit\Framework\TestCase
         return $mock;
     }
 
+    protected function expectCallableOnceWith($arg)
+    {
+        $mock = $this->createCallableMock();
+
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($arg);
+
+        return $mock;
+    }
+
     protected function expectCallableNever()
     {
         $mock = $this->createCallableMock();
@@ -33,28 +44,14 @@ class TestCase extends PHPUnit\Framework\TestCase
         return $mock;
     }
 
-    protected function expectCallableOnceWithExceptionCode($code)
+    protected function expectCallableOnceWithException($class, $message, $code)
     {
-        $mock = $this->createCallableMock();
-        $mock
-            ->expects($this->once())
-            ->method('__invoke')
-            ->with($this->callback(function ($e) use ($code) {
-                return $e->getCode() === $code;
-            }));
-
-        return $mock;
-    }
-
-    protected function expectCallableOnceParameter($type)
-    {
-        $mock = $this->createCallableMock();
-        $mock
-            ->expects($this->once())
-            ->method('__invoke')
-            ->with($this->isInstanceOf($type));
-
-        return $mock;
+        return $this->expectCallableOnceWith($this->logicalAnd(
+            $this->isInstanceOf($class),
+            $this->callback(function (\Exception $e) use ($message, $code) {
+                return strpos($e->getMessage(), $message) !== false && $e->getCode() === $code;
+            })
+        ));
     }
 
     /**


### PR DESCRIPTION
Builds on top of #82 and https://github.com/clue/reactphp-http-proxy/pull/26 and reactphp/socket#168, reactphp/socket#169, reactphp/socket#170, reactphp/socket#171, reactphp/socket#176 and reactphp/socket#177