### PR TITLE
 Replace Server::setAuth() with optional `Server` constructor parameter 

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,6 +628,10 @@ $server->listen($socket);
 $loop->run();
 ```
 
+Additionally, the `Server` constructor accepts optional parameters to explicitly
+configure the [connector](#server-connector) to use and to require
+[authentication](#server-authentication). For more details, read on...
+
 #### Server connector
 
 The `Server` uses an instance of ReactPHP's
@@ -674,32 +678,43 @@ If a client tries to use any other protocol version, does not send along
 authentication details or if authentication details can not be verified,
 the connection will be rejected.
 
-Because your authentication mechanism might take some time to actually check
-the provided authentication credentials (like querying a remote database or webservice),
-the server side uses a [Promise](https://github.com/reactphp/promise)-based interface.
-While this might seem complex at first, it actually provides a very simple way
-to handle simultanous connections in a non-blocking fashion and increases overall performance.
+If you only want to accept static authentication details, you can simply pass an
+additional assoc array with your authentication details to the `Server` like this:
 
-You can use the `setAuth(callable $authenticator)` method to configure a callable
+```php
+$server = new Clue\React\Socks\Server($loop, null, array(
+    'tom' => 'password',
+    'admin' => 'root'
+));
+```
+
+See also [example #12](examples).
+
+If you want more control over authentication, you can pass an authenticator
 function that should return a `bool` value like this synchronous example:
 
 ```php
-$server->setAuth(function ($username, $password, $remote) {
+$server = new Clue\React\Socks\Server($loop, null, function ($user, $pass, $remote) {
     // $remote is a full URI à la socks5://user:pass@192.168.1.1:1234
     // or socks5s://user:pass@192.168.1.1:1234 for SOCKS over TLS
     // useful for logging or extracting parts, such as the remote IP
     $ip = parse_url($remote, PHP_URL_HOST);
 
-    return ($username === 'root' && $password === 'secret' && $ip === '127.0.0.1');
+    return ($user === 'root' && $pass === 'secret' && $ip === '127.0.0.1');
 });
 ```
 
-Similarly, you can return a [Promise](https://github.com/reactphp/promise) from
-the authenticator function that will fulfill with a `bool` value like this async
-example:
+Because your authentication mechanism might take some time to actually check the
+provided authentication credentials (like querying a remote database or webservice),
+the server also supports a [Promise](https://github.com/reactphp/promise)-based
+interface. While this might seem more complex at first, it actually provides a
+very powerful way of handling a large number of connections concurrently without
+ever blocking any connections. You can return a [Promise](https://github.com/reactphp/promise)
+from the authenticator function that will fulfill with a `bool` value like this
+async example:
 
 ```php
-$server->setAuth(function ($username, $password) use ($db) {
+$server = new Clue\React\Socks\Server($loop, null, function ($user, $pass) use ($db) {
     // pseudo-code: query database for given authentication details
     return $db->query(
         'SELECT 1 FROM users WHERE name = ? AND password = ?',
@@ -709,24 +724,6 @@ $server->setAuth(function ($username, $password) use ($db) {
         return count($result->resultRows) === 1;
     });
 });
-```
-
-Or if you only accept static authentication details, you can use the simple
-array-based authentication method as a shortcut:
-
-```PHP
-$server->setAuthArray(array(
-    'tom' => 'password',
-    'admin' => 'root'
-));
-```
-
-See also [example #12](examples).
-
-If you do not want to use authentication anymore:
-
-```PHP
-$server->unsetAuth();
 ```
 
 #### Server proxy chaining

--- a/examples/12-server-with-password.php
+++ b/examples/12-server-with-password.php
@@ -9,8 +9,7 @@ $loop = React\EventLoop\Factory::create();
 
 // start a new SOCKS proxy server
 // require authentication and hence make this a SOCKS5-only server
-$server = new Server($loop);
-$server->setAuthArray(array(
+$server = new Server($loop, null, array(
     'tom' => 'god',
     'user' => 'p@ssw0rd'
 ));

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -302,6 +302,39 @@ class FunctionalTest extends TestCase
         $this->assertRejectPromise($this->client->connect('www.google.com:80'), null, SOCKET_EACCES);
     }
 
+    public function testConnectionInvalidAuthenticatorReturnsFalse()
+    {
+        $this->server->setAuth(function () {
+            return false;
+        });
+
+        $this->client = new Client('user:pass@127.0.0.1:' . $this->port, $this->connector);
+
+        $this->assertRejectPromise($this->client->connect('www.google.com:80'), null, SOCKET_EACCES);
+    }
+
+    public function testConnectionInvalidAuthenticatorReturnsPromiseFulfilledWithFalse()
+    {
+        $this->server->setAuth(function () {
+            return \React\Promise\resolve(false);
+        });
+
+        $this->client = new Client('user:pass@127.0.0.1:' . $this->port, $this->connector);
+
+        $this->assertRejectPromise($this->client->connect('www.google.com:80'), null, SOCKET_EACCES);
+    }
+
+    public function testConnectionInvalidAuthenticatorReturnsPromiseRejected()
+    {
+        $this->server->setAuth(function () {
+            return \React\Promise\reject();
+        });
+
+        $this->client = new Client('user:pass@127.0.0.1:' . $this->port, $this->connector);
+
+        $this->assertRejectPromise($this->client->connect('www.google.com:80'), null, SOCKET_EACCES);
+    }
+
     /** @group internet */
     public function testConnectorOkay()
     {

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -6,19 +6,21 @@ use React\Promise\Timer\TimeoutException;
 
 class ServerTest extends TestCase
 {
+    private $loop;
+    private $connector;
+
     /** @var Server */
     private $server;
-    private $connector;
 
     public function setUp()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')
+        $this->loop = $this->getMockBuilder('React\EventLoop\LoopInterface')
             ->getMock();
 
         $this->connector = $this->getMockBuilder('React\Socket\ConnectorInterface')
             ->getMock();
 
-        $this->server = new Server($loop, $this->connector);
+        $this->server = new Server($this->loop, $this->connector);
     }
 
     /**
@@ -31,24 +33,31 @@ class ServerTest extends TestCase
         $this->server->listen($socket);
     }
 
-    public function testSetAuthArray()
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testConstructorWithEmptyAuthArray()
     {
-        $this->server->setAuthArray(array());
+        $this->server = new Server($this->loop, $this->connector, array());
+    }
 
-        $this->server->setAuthArray(array(
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testConstructorWithStaticAuthArray()
+    {
+        $this->server = new Server($this->loop, $this->connector, array(
             'name1' => 'password1',
             'name2' => 'password2'
         ));
-
-        $this->assertTrue(true);
     }
 
     /**
      * @expectedException InvalidArgumentException
      */
-    public function testSetAuthInvalid()
+    public function testConstructorWithInvalidAuthenticatorThrows()
     {
-        $this->server->setAuth(true);
+        new Server($this->loop, $this->connector, true);
     }
 
     public function testConnectWillCreateConnection()
@@ -382,13 +391,5 @@ class ServerTest extends TestCase
 
         $connection->emit('data', array("\x04\x01" . "\x00\x50" . pack('N', ip2long('127.0.0.1')) . "\x00"));
         $connection->emit('close');
-    }
-
-    public function testUnsetAuth()
-    {
-        $this->server->unsetAuth();
-        $this->server->unsetAuth();
-
-        $this->assertTrue(true);
     }
 }


### PR DESCRIPTION
```php
// old
$server = new Clue\React\Socks\Server($loop);
$server->setAuthArray(array(
    'tom' => 'password',
    'admin' => 'root'
));

// new
$server = new Clue\React\Socks\Server($loop, null, array(
    'tom' => 'password',
    'admin' => 'root'
));
```

Refs #80