### PR TITLE
URI scheme socks5:// acts only as an alias for default socks:// scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,15 @@ a generic proxy allowing higher level application protocols to work through it.
 By default, the `Client` communicates via SOCKS5 with the SOCKS server.
 This is done because SOCKS5 is the latest version from the SOCKS protocol family
 and generally has best support across other vendors.
+You can also omit the default `socks://` URI scheme. Similarly, the `socks5://`
+URI scheme acts as an alias for the default `socks://` URI scheme.
+
+```php
+// all three forms are equivalent
+$client = new Client('127.0.0.1', $connector);
+$client = new Client('socks://127.0.0.1', $connector);
+$client = new Client('socks5://127.0.0.1', $connector);
+```
 
 If want to explicitly set the protocol version to SOCKS4(a), you can use the URI
 scheme `socks4://` as part of the SOCKS URI:
@@ -544,7 +553,7 @@ You can use the `sockss://` URI scheme or use an explicit
 ```php
 $client = new Client('sockss://127.0.0.1:1080', new Connector($loop));
 
-$client = new Client('socks5s://127.0.0.1:1080', new Connector($loop));
+$client = new Client('socks4s://127.0.0.1:1080', new Connector($loop));
 ```
 
 See also [example 32](examples).
@@ -587,7 +596,7 @@ You can use the `socks+unix://` URI scheme or use an explicit
 ```php
 $client = new Client('socks+unix:///tmp/proxy.sock', new Connector($loop));
 
-$client = new Client('socks5+unix:///tmp/proxy.sock', new Connector($loop));
+$client = new Client('socks4+unix:///tmp/proxy.sock', new Connector($loop));
 ```
 
 Similarly, you can also combine this with [authentication](#authentication)
@@ -661,7 +670,8 @@ Internally, the `Server` uses ReactPHP's normal
 [`connect()`](https://github.com/reactphp/socket#connect) method, but
 it also passes the original client IP as the `?source={remote}` parameter.
 The `source` parameter contains the full remote URI, including the protocol
-and any authentication details, for example `socks5://user:pass@1.2.3.4:5678`.
+and any authentication details, for example `socks://user:pass@1.2.3.4:5678`
+or `socks4://1.2.3.4:5678` for legacy SOCKS4(a).
 You can use this parameter for logging purposes or to restrict connection
 requests for certain clients by providing a custom implementation of the
 [`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface).
@@ -695,8 +705,9 @@ function that should return a `bool` value like this synchronous example:
 
 ```php
 $server = new Clue\React\Socks\Server($loop, null, function ($user, $pass, $remote) {
-    // $remote is a full URI à la socks5://user:pass@192.168.1.1:1234
-    // or socks5s://user:pass@192.168.1.1:1234 for SOCKS over TLS
+    // $remote is a full URI à la socks://user:pass@192.168.1.1:1234
+    // or sockss://user:pass@192.168.1.1:1234 for SOCKS over TLS
+    // or may be null when remote is unknown (SOCKS over Unix Domain Sockets)
     // useful for logging or extracting parts, such as the remote IP
     $ip = parse_url($remote, PHP_URL_HOST);
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -218,7 +218,7 @@ final class Server
             if (($pos = strpos($remote, '://')) !== false) {
                 $remote = substr($remote, $pos + 3);
             }
-            $remote = 'socks5' . ($secure ? 's' : '') . '://' . $remote;
+            $remote = 'socks' . ($secure ? 's' : '') . '://' . $remote;
         }
 
         $that = $this;

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -214,7 +214,7 @@ class FunctionalTest extends TestCase
             ++$called;
             $that->assertEquals('name', $name);
             $that->assertEquals('pass', $pass);
-            $that->assertStringStartsWith('socks5://name:pass@127.0.0.1:', $remote);
+            $that->assertStringStartsWith('socks://name:pass@127.0.0.1:', $remote);
 
             return true;
         });

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -79,9 +79,9 @@ class ServerTest extends TestCase
 
         $promise = new Promise(function () { });
 
-        $this->connector->expects($this->once())->method('connect')->with('google.com:80?source=socks5%3A%2F%2F10.20.30.40%3A5060')->willReturn($promise);
+        $this->connector->expects($this->once())->method('connect')->with('google.com:80?source=socks%3A%2F%2F10.20.30.40%3A5060')->willReturn($promise);
 
-        $promise = $this->server->connectTarget($stream, array('google.com', 80, 'socks5://10.20.30.40:5060'));
+        $promise = $this->server->connectTarget($stream, array('google.com', 80, 'socks://10.20.30.40:5060'));
 
         $this->assertInstanceOf('React\Promise\PromiseInterface', $promise);
     }
@@ -291,7 +291,7 @@ class ServerTest extends TestCase
 
         $promise = new Promise(function () { });
 
-        $this->connector->expects($this->once())->method('connect')->with('127.0.0.1:80?source=socks5%3A%2F%2F10.20.30.40%3A5060')->willReturn($promise);
+        $this->connector->expects($this->once())->method('connect')->with('127.0.0.1:80?source=socks%3A%2F%2F10.20.30.40%3A5060')->willReturn($promise);
 
         $this->server->onConnection($connection);
 
@@ -305,7 +305,7 @@ class ServerTest extends TestCase
 
         $promise = new Promise(function () { });
 
-        $this->connector->expects($this->once())->method('connect')->with('127.0.0.1:80?source=socks5s%3A%2F%2F10.20.30.40%3A5060')->willReturn($promise);
+        $this->connector->expects($this->once())->method('connect')->with('127.0.0.1:80?source=sockss%3A%2F%2F10.20.30.40%3A5060')->willReturn($promise);
 
         $this->server->onConnection($connection);
 


### PR DESCRIPTION
Builds on top of #74 and #81