### PR TITLE
Avoid PHP warnings due to lack of args in exception trace on PHP 7.4

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -192,13 +192,19 @@ final class Client implements ConnectorInterface
                 $r = new \ReflectionProperty('Exception', 'trace');
                 $r->setAccessible(true);
                 $trace = $r->getValue($e);
+
+                // Exception trace arguments are not available on some PHP 7.4 installs
+                // @codeCoverageIgnoreStart
                 foreach ($trace as &$one) {
-                    foreach ($one['args'] as &$arg) {
-                        if ($arg instanceof \Closure) {
-                            $arg = 'Object(' . get_class($arg) . ')';
+                    if (isset($one['args'])) {
+                        foreach ($one['args'] as &$arg) {
+                            if ($arg instanceof \Closure) {
+                                $arg = 'Object(' . \get_class($arg) . ')';
+                            }
                         }
                     }
                 }
+                // @codeCoverageIgnoreEnd
                 $r->setValue($e, $trace);
             }
         );


### PR DESCRIPTION
Some installations of PHP 7.4 do not report the "args" in the exception trace anymore due to the new `zend.exception_ignore_args` INI setting. This can lead to reporting some PHP warnings (`PHP Warning:  Invalid argument supplied for foreach()`) and/or rejected promises depending on the error handler used.

Accordingly, this didn't show up during unit tests because PHPUnit transforms these warnings into exceptions automatically which will cause the underlying promise to be rejected – which will not be reported by default (https://github.com/reactphp/promise/issues/87). This can be best reproduced by running one of the examples with an invalid SOCKS proxy setup and error reporting enabled. This should now report a promise rejection without any PHP warnings.

Builds on top of https://github.com/clue/reactphp-http-proxy/pull/33 and #82.