### PR TITLE
Update PHPUnit configuration schema for PHPUnit 9.3 and use Number Codes if Error Constants are undefined

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@
 /.travis.yml export-ignore
 /examples/ export-ignore
 /phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
 /tests/ export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 # lock distro so new future defaults will not break the build
 dist: trusty
 
-matrix:
+jobs:
   include:
     - php: 5.3
       dist: precise
@@ -19,10 +19,9 @@ matrix:
   allow_failures:
     - php: hhvm-3.18
 
-sudo: false
-
 install:
-  - composer install --no-interaction
+  - composer install
 
 script:
-  - vendor/bin/phpunit --coverage-text
+  - if [[ "$TRAVIS_PHP_VERSION" > "7.2" ]]; then vendor/bin/phpunit --coverage-text; fi
+  - if [[ "$TRAVIS_PHP_VERSION" < "7.3" ]]; then vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy; fi

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "react/socket": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0 || ^7.0 || ^6.0 || ^5.7 || ^4.8.35",
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
         "clue/connection-manager-extra": "^1.0 || ^0.7",
         "clue/block-react": "^1.1"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResult="false">
     <testsuites>
         <testsuite name="Socks Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Socks Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -168,7 +168,7 @@ class ClientTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'Connection to tcp://google.com:80 failed because connection to proxy failed (ECONNREFUSED)',
-            SOCKET_ECONNREFUSED
+            defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111
         ));
     }
 
@@ -186,7 +186,7 @@ class ClientTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'Connection to tcp://google.com:80 cancelled while waiting for proxy (ECONNABORTED)',
-            SOCKET_ECONNABORTED
+            defined('SOCKET_ECONNABORTED') ? SOCKET_ECONNABORTED : 103
         ));
     }
 
@@ -205,7 +205,7 @@ class ClientTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'Connection to tcp://google.com:80 cancelled while waiting for proxy (ECONNABORTED)',
-            SOCKET_ECONNABORTED
+            defined('SOCKET_ECONNABORTED') ? SOCKET_ECONNABORTED : 103
         ));
     }
 
@@ -225,7 +225,7 @@ class ClientTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'Connection to tcp://google.com:80 cancelled while waiting for proxy (ECONNABORTED)',
-            SOCKET_ECONNABORTED
+            defined('SOCKET_ECONNABORTED') ? SOCKET_ECONNABORTED : 103
         ));
     }
 
@@ -244,7 +244,7 @@ class ClientTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'Connection to tcp://google.com:80 failed because connection to proxy was lost while waiting for response from proxy (ECONNRESET)',
-            SOCKET_ECONNRESET
+            defined('SOCKET_ECONNRESET') ? SOCKET_ECONNRESET : 104
         ));
     }
 
@@ -263,7 +263,7 @@ class ClientTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'Connection to tcp://google.com:80 failed because connection to proxy caused a stream error (EIO)',
-            SOCKET_EIO
+            defined('SOCKET_EIO') ? SOCKET_EIO : 5
         ));
     }
 
@@ -283,7 +283,7 @@ class ClientTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'Connection to tcp://google.com:80 failed because proxy returned invalid response (EBADMSG)',
-            SOCKET_EBADMSG
+            defined('SOCKET_EBADMSG') ? SOCKET_EBADMSG: 71
         ));
     }
 
@@ -305,7 +305,7 @@ class ClientTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'Connection to tcp://google.com:80 failed because proxy returned invalid response (EBADMSG)',
-            SOCKET_EBADMSG
+            defined('SOCKET_EBADMSG') ? SOCKET_EBADMSG: 71
         ));
     }
 
@@ -327,7 +327,7 @@ class ClientTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'Connection to tcp://google.com:80 failed because proxy refused connection with general server failure (ECONNREFUSED)',
-            SOCKET_ECONNREFUSED
+            defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111
         ));
     }
 
@@ -349,7 +349,7 @@ class ClientTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'Connection to tcp://google.com:80 failed because proxy denied access due to unsupported authentication method (EACCES)',
-            SOCKET_EACCES
+            defined('SOCKET_EACCES') ? SOCKET_EACCES : 13
         ));
     }
 
@@ -371,7 +371,7 @@ class ClientTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'Connection to tcp://google.com:80 failed because proxy denied access with given authentication details (EACCES)',
-            SOCKET_EACCES
+            defined('SOCKET_EACCES') ? SOCKET_EACCES : 13
         ));
     }
 
@@ -393,7 +393,7 @@ class ClientTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'Connection to tcp://google.com:80 failed because proxy returned invalid response (EBADMSG)',
-            SOCKET_EBADMSG
+            defined('SOCKET_EBADMSG') ? SOCKET_EBADMSG: 71
         ));
     }
 
@@ -415,7 +415,7 @@ class ClientTest extends TestCase
         $promise->then(null, $this->expectCallableOnceWithException(
             'RuntimeException',
             'Connection to tcp://google.com:80 failed because proxy refused connection with error code 0x55 (ECONNREFUSED)',
-            SOCKET_ECONNREFUSED
+            defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111
         ));
     }
 
@@ -460,47 +460,47 @@ class ClientTest extends TestCase
         return array(
             array(
                 Server::ERROR_GENERAL,
-                SOCKET_ECONNREFUSED,
+                defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111,
                 'failed because proxy refused connection with general server failure (ECONNREFUSED)'
             ),
             array(
                 Server::ERROR_NOT_ALLOWED_BY_RULESET,
-                SOCKET_EACCES,
+                defined('SOCKET_EACCES') ? SOCKET_EACCES : 13,
                 'failed because proxy denied access due to ruleset (EACCES)'
             ),
             array(
                 Server::ERROR_NETWORK_UNREACHABLE,
-                SOCKET_ENETUNREACH,
+                defined('SOCKET_ENETUNREACH') ? SOCKET_ENETUNREACH : 101,
                 'failed because proxy reported network unreachable (ENETUNREACH)'
             ),
             array(
                 Server::ERROR_HOST_UNREACHABLE,
-                SOCKET_EHOSTUNREACH,
+                defined('SOCKET_EHOSTUNREACH') ? SOCKET_EHOSTUNREACH : 113,
                 'failed because proxy reported host unreachable (EHOSTUNREACH)'
             ),
             array(
                 Server::ERROR_CONNECTION_REFUSED,
-                SOCKET_ECONNREFUSED,
+                defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111,
                 'failed because proxy reported connection refused (ECONNREFUSED)'
             ),
             array(
                 Server::ERROR_TTL,
-                SOCKET_ETIMEDOUT,
+                defined('SOCKET_ETIMEDOUT') ? SOCKET_ETIMEDOUT : 110,
                 'failed because proxy reported TTL/timeout expired (ETIMEDOUT)'
             ),
             array(
                 Server::ERROR_COMMAND_UNSUPPORTED,
-                SOCKET_EPROTO,
+                defined('SOCKET_EPROTO') ? SOCKET_EPROTO : 71,
                 'failed because proxy does not support the CONNECT command (EPROTO)'
             ),
             array(
                 Server::ERROR_ADDRESS_UNSUPPORTED,
-                SOCKET_EPROTO,
+                defined('SOCKET_EPROTO') ? SOCKET_EPROTO : 71,
                 'failed because proxy does not support this address type (EPROTO)'
             ),
             array(
                 200,
-                SOCKET_ECONNREFUSED,
+                defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111,
                 'failed because proxy server refused connection with unknown error code 0xC8 (ECONNREFUSED)'
             )
         );

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -327,7 +327,7 @@ class FunctionalTest extends TestCase
 
         $this->client = new Client('socks5://127.0.0.1:' . $this->port, $this->connector);
 
-        $this->assertRejectPromise($this->client->connect('www.google.com:80'), null, SOCKET_EACCES);
+        $this->assertRejectPromise($this->client->connect('www.google.com:80'), null, defined('SOCKET_EACCES') ? SOCKET_EACCES : 13);
     }
 
     public function testConnectionInvalidAuthenticationMismatch()
@@ -340,7 +340,7 @@ class FunctionalTest extends TestCase
 
         $this->client = new Client('user:pass@127.0.0.1:' . $this->port, $this->connector);
 
-        $this->assertRejectPromise($this->client->connect('www.google.com:80'), null, SOCKET_EACCES);
+        $this->assertRejectPromise($this->client->connect('www.google.com:80'), null, defined('SOCKET_EACCES') ? SOCKET_EACCES : 13);
     }
 
     public function testConnectionInvalidAuthenticatorReturnsFalse()
@@ -355,7 +355,7 @@ class FunctionalTest extends TestCase
 
         $this->client = new Client('user:pass@127.0.0.1:' . $this->port, $this->connector);
 
-        $this->assertRejectPromise($this->client->connect('www.google.com:80'), null, SOCKET_EACCES);
+        $this->assertRejectPromise($this->client->connect('www.google.com:80'), null, defined('SOCKET_EACCES') ? SOCKET_EACCES : 13);
     }
 
     public function testConnectionInvalidAuthenticatorReturnsPromiseFulfilledWithFalse()
@@ -370,7 +370,7 @@ class FunctionalTest extends TestCase
 
         $this->client = new Client('user:pass@127.0.0.1:' . $this->port, $this->connector);
 
-        $this->assertRejectPromise($this->client->connect('www.google.com:80'), null, SOCKET_EACCES);
+        $this->assertRejectPromise($this->client->connect('www.google.com:80'), null, defined('SOCKET_EACCES') ? SOCKET_EACCES : 13);
     }
 
     public function testConnectionInvalidAuthenticatorReturnsPromiseRejected()
@@ -385,7 +385,7 @@ class FunctionalTest extends TestCase
 
         $this->client = new Client('user:pass@127.0.0.1:' . $this->port, $this->connector);
 
-        $this->assertRejectPromise($this->client->connect('www.google.com:80'), null, SOCKET_EACCES);
+        $this->assertRejectPromise($this->client->connect('www.google.com:80'), null, defined('SOCKET_EACCES') ? SOCKET_EACCES : 13);
     }
 
     /** @group internet */

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -141,19 +141,19 @@ class ServerTest extends TestCase
     {
         return array(
             array(
-                new \RuntimeException('', SOCKET_EACCES),
+                new \RuntimeException('', defined('SOCKET_EACCES') ? SOCKET_EACCES : 13),
                 Server::ERROR_NOT_ALLOWED_BY_RULESET
             ),
             array(
-                new \RuntimeException('', SOCKET_ENETUNREACH),
+                new \RuntimeException('', defined('SOCKET_ENETUNREACH') ? SOCKET_ENETUNREACH : 101),
                 Server::ERROR_NETWORK_UNREACHABLE
             ),
             array(
-                new \RuntimeException('', SOCKET_EHOSTUNREACH),
+                new \RuntimeException('', defined('SOCKET_EHOSTUNREACH') ? SOCKET_EHOSTUNREACH : 113),
                 Server::ERROR_HOST_UNREACHABLE,
             ),
             array(
-                new \RuntimeException('', SOCKET_ECONNREFUSED),
+                new \RuntimeException('', defined('SOCKET_ECONNREFUSED') ? SOCKET_ECONNREFUSED : 111),
                 Server::ERROR_CONNECTION_REFUSED
             ),
             array(
@@ -161,7 +161,7 @@ class ServerTest extends TestCase
                 Server::ERROR_CONNECTION_REFUSED
             ),
             array(
-                new \RuntimeException('', SOCKET_ETIMEDOUT),
+                new \RuntimeException('', defined('SOCKET_ETIMEDOUT') ? SOCKET_ETIMEDOUT : 110),
                 Server::ERROR_TTL
             ),
             array(


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.
For further details concerning this pull request look into https://github.com/graphp/graphviz/pull/46.
This pull request builds on top of #93.

It's also possible to run this code with PHP 8 🎉
 ```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.0.0beta2-cli php vendor/bin/phpunit
PHPUnit 9.4.2 by Sebastian Bergmann and contributors.

...............................................................  63 / 118 ( 53%)
.......................................................         118 / 118 (100%)

Time: 00:03.161, Memory: 10.00 MB

OK (118 tests, 328 assertions)
```